### PR TITLE
BE2-04: Add repository test for valid token case

### DIFF
--- a/backend/internal/repository/file_repository_test.go
+++ b/backend/internal/repository/file_repository_test.go
@@ -2,9 +2,46 @@ package repository
 
 import (
 	"testing"
-
 	"sharex-backend/internal/database"
+	"sharex-backend/internal/models"
 )
+
+func TestGetByToken_ValidToken(t *testing.T) {
+	repo := &FileRepository{}
+
+	// Skip if DB not initialized
+	if database.DB == nil {
+		t.Skip("Skipping test because database is not initialized")
+	}
+
+	// 🔥 Create dummy file
+	testFile := &models.File{
+		Filename: "test.txt",
+		Filepath: "/tmp/test.txt",
+		Token:    "valid-token-123",
+		Size:     100,
+	}
+
+	// Insert into DB
+	err := repo.Create(testFile)
+	if err != nil {
+		t.Fatalf("Failed to insert test file: %v", err)
+	}
+
+	// Fetch using token
+	result, err := repo.GetByToken(testFile.Token)
+	if err != nil {
+		t.Fatalf("Expected no error, got %v", err)
+	}
+
+	if result == nil {
+		t.Fatalf("Expected file, got nil")
+	}
+
+	if result.Token != testFile.Token {
+		t.Errorf("Expected token %v, got %v", testFile.Token, result.Token)
+	}
+}
 
 func TestGetByToken_InvalidToken(t *testing.T) {
 	repo := &FileRepository{}


### PR DESCRIPTION
This PR adds a test for the GetByToken repository function with a valid token.

- Inserts test file into database
- Retrieves file using token
- Validates returned data
- Skips test if database is not initialized