### PR TITLE
Added metadata handler invalid token test (closes #72)

### DIFF
--- a/backend/internal/handlers/metadata_test.go
+++ b/backend/internal/handlers/metadata_test.go
@@ -8,6 +8,31 @@ import (
 	"sharex-backend/internal/database"
 )
 
+func TestMetadataHandler_InvalidToken(t *testing.T) {
+	// Skip if DB not initialized (prevents crash)
+	if database.DB == nil {
+		t.Skip("Skipping test because database is not initialized")
+	}
+
+	req, err := http.NewRequest("GET", "/file/invalid-token", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+
+	handler := http.HandlerFunc(MetadataHandler)
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("Expected status 404, got %d", rr.Code)
+	}
+
+	if rr.Body.String() == "" {
+		t.Errorf("Expected error response body")
+	}
+}
+
 func TestMetadataHandler_Success(t *testing.T) {
 	// 🔥 Prevent crash if DB not initialized
 	if database.DB == nil {


### PR DESCRIPTION
This PR adds a test for metadata handler with an invalid token.

- Verifies 404 response for invalid token
- Ensures proper error handling
- Includes safe DB check to prevent crashes