### PR TITLE
BE2-15: Preserve original filename in download response

### DIFF
--- a/backend/internal/handlers/download_handler.go
+++ b/backend/internal/handlers/download_handler.go
@@ -3,7 +3,6 @@ package handlers
 import (
 	"net/http"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"sharex-backend/internal/repository"
@@ -32,10 +31,7 @@ func DownloadHandler(w http.ResponseWriter, r *http.Request) {
 	}
 	defer file.Close()
 
-	filename := filepath.Base(fileMeta.Filepath)
-	if idx := strings.Index(filename, "_"); idx != -1 && idx+1 < len(filename) {
-		filename = filename[idx+1:]
-	}
+	filename := fileMeta.Filename
 
 	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
 	http.ServeContent(w, r, filename, fileMeta.CreatedAt, file)


### PR DESCRIPTION
## Summary
Ensures the downloaded file always uses the original uploaded filename
in the Content-Disposition header, not the token-prefixed storage name.

## Changes
- Use `fileMeta.Filename` directly from DB record instead of parsing filepath
- Removed unused `path/filepath` import

## Testing
- Upload a file named `report.pdf` → download it → browser saves it as `report.pdf`
- Token prefix is never exposed to the user

Closes #80 