### PR TITLE
BE2-16: Add unit tests for upload handler

### DIFF
--- a/backend/internal/handlers/upload_handler_test.go
+++ b/backend/internal/handlers/upload_handler_test.go
@@ -1,0 +1,77 @@
+package handlers
+
+import (
+	"bytes"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestUploadHandler_MissingFile(t *testing.T) {
+	req, err := http.NewRequest("POST", "/upload", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(UploadHandler)
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %v", rr.Code)
+	}
+}
+
+func TestUploadHandler_EmptyFile(t *testing.T) {
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	_, err := writer.CreateFormFile("file", "empty.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	writer.Close()
+
+	req, err := http.NewRequest("POST", "/upload", &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(UploadHandler)
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("Expected status 400, got %v", rr.Code)
+	}
+}
+
+func TestUploadHandler_ValidFile_DBNotInitialized(t *testing.T) {
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	fw, err := writer.CreateFormFile("file", "test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fw.Write([]byte("hello world"))
+	writer.Close()
+
+	req, err := http.NewRequest("POST", "/upload", &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(UploadHandler)
+
+	handler.ServeHTTP(rr, req)
+
+	// Without DB, expect 500 — confirms handler reaches DB step
+	if rr.Code != http.StatusInternalServerError {
+		t.Errorf("Expected status 500, got %v", rr.Code)
+	}
+}


### PR DESCRIPTION
## Summary
Adds unit tests for the upload handler covering missing file,
empty file, and valid file (DB not initialized) cases.

## Changes
- New file: `upload_handler_test.go`
- 3 test cases covering bad request and error paths

## Testing
Run with: `go test ./internal/handlers/...`

Closes #81