### PR TITLE
Added reusable test helpers and updated metadata tests (closes #74)

### DIFF
--- a/backend/internal/handlers/metadata_test.go
+++ b/backend/internal/handlers/metadata_test.go
@@ -2,24 +2,19 @@ package handlers
 
 import (
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"sharex-backend/internal/database"
+	"sharex-backend/internal/utils"
 )
 
 func TestMetadataHandler_InvalidToken(t *testing.T) {
-	// Skip if DB not initialized (prevents crash)
 	if database.DB == nil {
 		t.Skip("Skipping test because database is not initialized")
 	}
 
-	req, err := http.NewRequest("GET", "/file/invalid-token", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	rr := httptest.NewRecorder()
+	req := utils.CreateTestRequest("GET", "/file/invalid-token")
+	rr := utils.CreateTestRecorder()
 
 	handler := http.HandlerFunc(MetadataHandler)
 	handler.ServeHTTP(rr, req)
@@ -34,17 +29,12 @@ func TestMetadataHandler_InvalidToken(t *testing.T) {
 }
 
 func TestMetadataHandler_Success(t *testing.T) {
-	// 🔥 Prevent crash if DB not initialized
 	if database.DB == nil {
 		t.Skip("Skipping test because database is not initialized")
 	}
 
-	req, err := http.NewRequest("GET", "/file/test-token", nil)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	rr := httptest.NewRecorder()
+	req := utils.CreateTestRequest("GET", "/file/test-token")
+	rr := utils.CreateTestRecorder()
 
 	handler := http.HandlerFunc(MetadataHandler)
 	handler.ServeHTTP(rr, req)

--- a/backend/internal/utils/test_helpers.go
+++ b/backend/internal/utils/test_helpers.go
@@ -1,0 +1,17 @@
+package utils
+
+import (
+	"net/http"
+	"net/http/httptest"
+)
+
+// CreateTestRequest creates a new HTTP request
+func CreateTestRequest(method, url string) *http.Request {
+	req, _ := http.NewRequest(method, url, nil)
+	return req
+}
+
+// CreateTestRecorder creates a response recorder
+func CreateTestRecorder() *httptest.ResponseRecorder {
+	return httptest.NewRecorder()
+}


### PR DESCRIPTION
This PR introduces reusable helper functions for testing.

- Added CreateTestRequest and CreateTestRecorder utilities
- Updated metadata handler tests to use helpers
- Reduces duplication and improves readability