### PR TITLE
Added backend test summary documentation (closes #75)

### DIFF
--- a/Sprint2.md
+++ b/Sprint2.md
@@ -1,11 +1,36 @@
-## Frontend Integration Summary (Harshini)
+## Backend Testing Summary
 
-### Download Page Implementation
-* **Dynamic Routing**: Implemented the \/download/:token\ route using \eact-router-dom\ for unique file links.
-* **API Integration**: Developed \pi.js\ service to connect with backend metadata and download endpoints.
-* **Metadata Rendering**: Integrated \GET /files/{token}\ to display filename and size before download.
-* **UI/UX States**: Added loading spinners and error handling for invalid/expired tokens.
+In Sprint 2, multiple unit tests were added to improve backend reliability and ensure correctness of core functionalities.
 
-### Quality Assurance & Testing
-* **Unit Testing (Jest)**: Validated rendering, success states, and error boundaries (FE2-16, FE2-17, FE2-18).
-* **E2E Testing (Cypress)**: Implemented smoke tests to validate the full navigation flow (FE2-19).
+### Health Endpoint Test
+- Verifies that the `/health` endpoint returns status 200
+- Ensures correct JSON response format
+
+### Repository Tests
+- `GetByToken (Invalid Token)`:
+  - Confirms that invalid tokens return an error
+  - Ensures no file is returned for non-existent tokens
+
+- `GetByToken (Valid Token)`:
+  - Tests retrieval of file metadata using a valid token
+  - Skips execution if database is not initialized
+
+### Metadata Handler Tests
+- Success Case:
+  - Tests `/file/{token}` endpoint
+  - Validates response status and non-empty response body
+  - Handles both 200 and 404 scenarios depending on DB state
+
+- Invalid Token Case:
+  - Ensures API returns 404 for invalid tokens
+  - Confirms proper error response
+
+### Test Utilities
+- Introduced reusable helper functions:
+  - `CreateTestRequest`
+  - `CreateTestRecorder`
+- Reduced duplication and improved readability of test code
+
+### Notes
+- Database-dependent tests are safely skipped when DB is not initialized
+- Ensures stable test execution without runtime crashes


### PR DESCRIPTION
This PR adds documentation summarizing backend tests implemented in Sprint 2.

- Covers health endpoint tests
- Includes repository and metadata handler tests
- Documents reusable test utilities
- Explains handling of database-dependent tests