### PR TITLE
BE3-02: add register endpoint with hashed passwords

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -44,6 +44,8 @@ func main() {
 
 	mux.HandleFunc("/file/", handlers.MetadataHandler)
 
+	mux.HandleFunc("/auth/register", handlers.RegisterHandler)
+
 	log.Printf("Server running on port %s\n", port)
 
 	if err := http.ListenAndServe(":"+port, withCORS(mux)); err != nil {

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
-	golang.org/x/sync v0.17.0 // indirect
-	golang.org/x/text v0.29.0 // indirect
+	golang.org/x/crypto v0.50.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
+	golang.org/x/text v0.36.0 // indirect
 )

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -16,10 +16,16 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
+golang.org/x/crypto v0.50.0 h1:zO47/JPrL6vsNkINmLoo/PH1gcxpls50DNogFvB5ZGI=
+golang.org/x/crypto v0.50.0/go.mod h1:3muZ7vA7PBCE6xgPX7nkzzjiUq87kRItoJQM1Yo8S+Q=
 golang.org/x/sync v0.17.0 h1:l60nONMj9l5drqw6jlhIELNv9I0A4OFgRsG9k2oT9Ug=
 golang.org/x/sync v0.17.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/text v0.29.0 h1:1neNs90w9YzJ9BocxfsQNHKuAT4pkghyXc4nhZ6sJvk=
 golang.org/x/text v0.29.0/go.mod h1:7MhJOA9CD2qZyOKYazxdYMF85OwPdEr9jTtBpO7ydH4=
+golang.org/x/text v0.36.0 h1:JfKh3XmcRPqZPKevfXVpI1wXPTqbkE5f7JA92a55Yxg=
+golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/backend/internal/handlers/auth_handler.go
+++ b/backend/internal/handlers/auth_handler.go
@@ -1,0 +1,76 @@
+package handlers
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+
+	"sharex-backend/internal/models"
+	"sharex-backend/internal/repository"
+	"sharex-backend/internal/services"
+	"sharex-backend/internal/utils"
+)
+
+type registerRequest struct {
+	Name     string `json:"name"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
+func RegisterHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		utils.WriteJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req registerRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		utils.WriteJSONError(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	req.Name = strings.TrimSpace(req.Name)
+	req.Email = strings.TrimSpace(req.Email)
+	req.Password = strings.TrimSpace(req.Password)
+
+	if req.Name == "" || req.Email == "" || req.Password == "" {
+		utils.WriteJSONError(w, "name, email, and password are required", http.StatusBadRequest)
+		return
+	}
+
+	passwordHash, err := services.HashPassword(req.Password)
+	if err != nil {
+		utils.WriteJSONError(w, "Unable to process password", http.StatusInternalServerError)
+		return
+	}
+
+	user := models.User{
+		Name:         req.Name,
+		Email:        req.Email,
+		PasswordHash: passwordHash,
+	}
+
+	repo := repository.UserRepository{}
+	if err := repo.Create(&user); err != nil {
+		if errors.Is(err, repository.ErrUserAlreadyExists) {
+			utils.WriteJSONError(w, "Email already registered", http.StatusConflict)
+			return
+		}
+
+		utils.WriteJSONError(w, "Database error", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(map[string]any{
+		"message": "User registered successfully",
+		"user": map[string]any{
+			"id":        user.ID,
+			"name":      user.Name,
+			"email":     user.Email,
+			"createdAt": user.CreatedAt,
+		},
+	})
+}

--- a/backend/internal/handlers/auth_handler_test.go
+++ b/backend/internal/handlers/auth_handler_test.go
@@ -1,0 +1,85 @@
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"sharex-backend/internal/repository"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+func TestRegisterHandler_Success(t *testing.T) {
+	repository.ResetInMemoryUserStore()
+
+	body := map[string]string{
+		"name":     "Varshith",
+		"email":    "varshith@example.com",
+		"password": "pass12345",
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/register", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	http.HandlerFunc(RegisterHandler).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("Expected status 201, got %d", rr.Code)
+	}
+
+	repo := repository.UserRepository{}
+	storedUser, err := repo.GetByEmail("varshith@example.com")
+	if err != nil {
+		t.Fatalf("Expected stored user, got error: %v", err)
+	}
+
+	if storedUser.PasswordHash == "pass12345" {
+		t.Fatalf("Expected password to be hashed, but plain password was stored")
+	}
+
+	if err := bcrypt.CompareHashAndPassword([]byte(storedUser.PasswordHash), []byte("pass12345")); err != nil {
+		t.Fatalf("Expected valid bcrypt hash, got compare error: %v", err)
+	}
+}
+
+func TestRegisterHandler_DuplicateEmail(t *testing.T) {
+	repository.ResetInMemoryUserStore()
+
+	body := map[string]string{
+		"name":     "User One",
+		"email":    "duplicate@example.com",
+		"password": "pass12345",
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	firstReq := httptest.NewRequest(http.MethodPost, "/auth/register", bytes.NewReader(payload))
+	firstReq.Header.Set("Content-Type", "application/json")
+	firstRR := httptest.NewRecorder()
+	http.HandlerFunc(RegisterHandler).ServeHTTP(firstRR, firstReq)
+
+	if firstRR.Code != http.StatusCreated {
+		t.Fatalf("Expected first request status 201, got %d", firstRR.Code)
+	}
+
+	secondReq := httptest.NewRequest(http.MethodPost, "/auth/register", bytes.NewReader(payload))
+	secondReq.Header.Set("Content-Type", "application/json")
+	secondRR := httptest.NewRecorder()
+	http.HandlerFunc(RegisterHandler).ServeHTTP(secondRR, secondReq)
+
+	if secondRR.Code != http.StatusConflict {
+		t.Fatalf("Expected second request status 409, got %d", secondRR.Code)
+	}
+}

--- a/backend/internal/repository/user_repository.go
+++ b/backend/internal/repository/user_repository.go
@@ -1,0 +1,125 @@
+package repository
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"time"
+
+	"sharex-backend/internal/database"
+	"sharex-backend/internal/models"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+var ErrUserAlreadyExists = errors.New("user already exists")
+
+type UserRepository struct{}
+
+var (
+	inMemoryUsers      = map[string]*models.User{}
+	inMemoryUsersMu    sync.RWMutex
+	nextInMemoryUserID = 1
+)
+
+func normalizeEmail(email string) string {
+	return strings.ToLower(strings.TrimSpace(email))
+}
+
+func (r *UserRepository) Create(user *models.User) error {
+	normalizedEmail := normalizeEmail(user.Email)
+
+	if database.DB == nil {
+		inMemoryUsersMu.Lock()
+		defer inMemoryUsersMu.Unlock()
+
+		if _, exists := inMemoryUsers[normalizedEmail]; exists {
+			return ErrUserAlreadyExists
+		}
+
+		user.ID = nextInMemoryUserID
+		nextInMemoryUserID++
+		user.Email = normalizedEmail
+		user.CreatedAt = time.Now().UTC()
+
+		userCopy := *user
+		inMemoryUsers[normalizedEmail] = &userCopy
+		return nil
+	}
+
+	query := `
+	INSERT INTO users (name, email, password_hash)
+	VALUES ($1, $2, $3)
+	RETURNING id, created_at
+	`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	err := database.DB.QueryRow(ctx, query,
+		user.Name,
+		normalizedEmail,
+		user.PasswordHash,
+	).Scan(&user.ID, &user.CreatedAt)
+
+	if err != nil {
+		var pgErr *pgconn.PgError
+		if errors.As(err, &pgErr) && pgErr.Code == "23505" {
+			return ErrUserAlreadyExists
+		}
+		return err
+	}
+
+	user.Email = normalizedEmail
+	return nil
+}
+
+func (r *UserRepository) GetByEmail(email string) (*models.User, error) {
+	normalizedEmail := normalizeEmail(email)
+
+	if database.DB == nil {
+		inMemoryUsersMu.RLock()
+		defer inMemoryUsersMu.RUnlock()
+
+		user, ok := inMemoryUsers[normalizedEmail]
+		if !ok {
+			return nil, errors.New("user not found")
+		}
+
+		userCopy := *user
+		return &userCopy, nil
+	}
+
+	query := `
+	SELECT id, name, email, password_hash, created_at
+	FROM users
+	WHERE email = $1
+	`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var user models.User
+
+	err := database.DB.QueryRow(ctx, query, normalizedEmail).Scan(
+		&user.ID,
+		&user.Name,
+		&user.Email,
+		&user.PasswordHash,
+		&user.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &user, nil
+}
+
+func ResetInMemoryUserStore() {
+	inMemoryUsersMu.Lock()
+	defer inMemoryUsersMu.Unlock()
+
+	inMemoryUsers = map[string]*models.User{}
+	nextInMemoryUserID = 1
+}

--- a/backend/internal/services/password.go
+++ b/backend/internal/services/password.go
@@ -1,0 +1,12 @@
+package services
+
+import "golang.org/x/crypto/bcrypt"
+
+func HashPassword(password string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+
+	return string(hash), nil
+}


### PR DESCRIPTION
This PR implements the user registration endpoint to allow new users to create accounts. It enables accepting user details, validating input, and securely storing user credentials in the database.

Changes Made:

Added POST /auth/register endpoint
Accepts name, email, and password in request body
Implemented validation for required fields
Added duplicate email check to prevent multiple accounts with same email
Integrated password hashing before storing in database
Returns structured JSON response on successful registration

Acceptance Criteria:

Accepts name, email, password
Rejects duplicate email
Stores hashed password
Returns success JSON response