### PR TITLE
BE3-03: add login endpoint with JWT auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,41 @@ cd backend
 go run ./cmd/server
 ```
 
+### Auth API Response Format
+
+`POST /auth/login`
+
+Request body:
+
+```json
+{
+    "email": "user@example.com",
+    "password": "your-password"
+}
+```
+
+Success response (`200 OK`):
+
+```json
+{
+    "message": "Login successful",
+    "token": "<signed-jwt>",
+    "user": {
+        "id": 1,
+        "name": "User Name",
+        "email": "user@example.com"
+    }
+}
+```
+
+Invalid credentials response (`401 Unauthorized`):
+
+```json
+{
+    "error": "Invalid email or password"
+}
+```
+
 ### Frontend
 
 ```bash

--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -45,6 +45,7 @@ func main() {
 	mux.HandleFunc("/file/", handlers.MetadataHandler)
 
 	mux.HandleFunc("/auth/register", handlers.RegisterHandler)
+	mux.HandleFunc("/auth/login", handlers.LoginHandler)
 
 	log.Printf("Server running on port %s\n", port)
 

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,7 @@ go 1.25.1
 require github.com/jackc/pgx/v5 v5.8.0
 
 require (
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=

--- a/backend/internal/handlers/auth_handler.go
+++ b/backend/internal/handlers/auth_handler.go
@@ -18,6 +18,11 @@ type registerRequest struct {
 	Password string `json:"password"`
 }
 
+type loginRequest struct {
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
 func RegisterHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		utils.WriteJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
@@ -71,6 +76,57 @@ func RegisterHandler(w http.ResponseWriter, r *http.Request) {
 			"name":      user.Name,
 			"email":     user.Email,
 			"createdAt": user.CreatedAt,
+		},
+	})
+}
+
+func LoginHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		utils.WriteJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	var req loginRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		utils.WriteJSONError(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	req.Email = strings.TrimSpace(req.Email)
+	req.Password = strings.TrimSpace(req.Password)
+
+	if req.Email == "" || req.Password == "" {
+		utils.WriteJSONError(w, "email and password are required", http.StatusBadRequest)
+		return
+	}
+
+	repo := repository.UserRepository{}
+	user, err := repo.GetByEmail(req.Email)
+	if err != nil {
+		utils.WriteJSONError(w, "Invalid email or password", http.StatusUnauthorized)
+		return
+	}
+
+	if !services.CheckPasswordHash(req.Password, user.PasswordHash) {
+		utils.WriteJSONError(w, "Invalid email or password", http.StatusUnauthorized)
+		return
+	}
+
+	token, err := services.GenerateJWT(user.ID, user.Email, user.Name)
+	if err != nil {
+		utils.WriteJSONError(w, "Unable to generate token", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]any{
+		"message": "Login successful",
+		"token":   token,
+		"user": map[string]any{
+			"id":    user.ID,
+			"name":  user.Name,
+			"email": user.Email,
 		},
 	})
 }

--- a/backend/internal/handlers/auth_handler_test.go
+++ b/backend/internal/handlers/auth_handler_test.go
@@ -5,10 +5,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
+	"sharex-backend/internal/models"
 	"sharex-backend/internal/repository"
+	"sharex-backend/internal/services"
 
+	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/crypto/bcrypt"
 )
 
@@ -81,5 +85,93 @@ func TestRegisterHandler_DuplicateEmail(t *testing.T) {
 
 	if secondRR.Code != http.StatusConflict {
 		t.Fatalf("Expected second request status 409, got %d", secondRR.Code)
+	}
+}
+
+func TestLoginHandler_SuccessReturnsJWT(t *testing.T) {
+	repository.ResetInMemoryUserStore()
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	hash, err := services.HashPassword("pass12345")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := repository.UserRepository{}
+	err = repo.Create(&models.User{Name: "Login User", Email: "login@example.com", PasswordHash: hash})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := map[string]string{
+		"email":    "login@example.com",
+		"password": "pass12345",
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/login", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	http.HandlerFunc(LoginHandler).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", rr.Code)
+	}
+
+	var response map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Expected valid JSON response: %v", err)
+	}
+
+	tokenRaw, ok := response["token"].(string)
+	if !ok || tokenRaw == "" {
+		t.Fatalf("Expected non-empty JWT token in response")
+	}
+
+	parsed, err := jwt.Parse(tokenRaw, func(token *jwt.Token) (any, error) {
+		return []byte(os.Getenv("JWT_SECRET")), nil
+	})
+	if err != nil || !parsed.Valid {
+		t.Fatalf("Expected valid signed JWT, got error: %v", err)
+	}
+}
+
+func TestLoginHandler_InvalidCredentials(t *testing.T) {
+	repository.ResetInMemoryUserStore()
+
+	hash, err := services.HashPassword("correct-password")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := repository.UserRepository{}
+	err = repo.Create(&models.User{Name: "Wrong Pass User", Email: "wrongpass@example.com", PasswordHash: hash})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	body := map[string]string{
+		"email":    "wrongpass@example.com",
+		"password": "wrong-password",
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPost, "/auth/login", bytes.NewReader(payload))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	http.HandlerFunc(LoginHandler).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("Expected status 401, got %d", rr.Code)
 	}
 }

--- a/backend/internal/services/jwt.go
+++ b/backend/internal/services/jwt.go
@@ -1,0 +1,27 @@
+package services
+
+import (
+	"os"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+)
+
+func GenerateJWT(userID int, email string, name string) (string, error) {
+	secret := os.Getenv("JWT_SECRET")
+	if secret == "" {
+		secret = "dev-secret-change-me"
+	}
+
+	now := time.Now().UTC()
+	claims := jwt.MapClaims{
+		"sub":   userID,
+		"email": email,
+		"name":  name,
+		"iat":   now.Unix(),
+		"exp":   now.Add(24 * time.Hour).Unix(),
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	return token.SignedString([]byte(secret))
+}

--- a/backend/internal/services/password.go
+++ b/backend/internal/services/password.go
@@ -10,3 +10,7 @@ func HashPassword(password string) (string, error) {
 
 	return string(hash), nil
 }
+
+func CheckPasswordHash(password string, hash string) bool {
+	return bcrypt.CompareHashAndPassword([]byte(hash), []byte(password)) == nil
+}


### PR DESCRIPTION
This PR implements the user login endpoint to authenticate existing users. It validates user credentials and returns a signed JWT token for authorized access to protected routes.

Changes Made:

Added POST /auth/login endpoint
Accepts email and password in request body
Validates user credentials against stored records
Compares hashed password securely
Generates and returns a signed JWT on successful authentication
Returns appropriate error response for invalid credentials

Acceptance Criteria:

Validates email and password
Returns signed JWT
Invalid credentials return 401
Response format documented