### PR TITLE
BE3-04: add JWT auth middleware for protected routes

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -7,6 +7,7 @@ import (
 
 	"sharex-backend/internal/database"
 	"sharex-backend/internal/handlers"
+	"sharex-backend/internal/middleware"
 )
 
 func main() {
@@ -38,7 +39,7 @@ func main() {
 
 	mux.HandleFunc("/health", handlers.HealthHandler)
 
-	mux.HandleFunc("/upload", handlers.UploadHandler)
+	mux.Handle("/upload", middleware.AuthMiddleware(http.HandlerFunc(handlers.UploadHandler)))
 
 	mux.HandleFunc("/download/", handlers.DownloadHandler)
 
@@ -58,7 +59,7 @@ func withCORS(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Access-Control-Allow-Origin", "http://localhost:3000")
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-		w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+		w.Header().Set("Access-Control-Allow-Headers", "Content-Type, Authorization")
 
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)

--- a/backend/internal/middleware/auth_middleware.go
+++ b/backend/internal/middleware/auth_middleware.go
@@ -1,0 +1,56 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"sharex-backend/internal/services"
+	"sharex-backend/internal/utils"
+)
+
+type contextKey string
+
+const userIDContextKey contextKey = "userID"
+
+func AuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authHeader := strings.TrimSpace(r.Header.Get("Authorization"))
+		if authHeader == "" {
+			utils.WriteJSONError(w, "Missing authorization token", http.StatusUnauthorized)
+			return
+		}
+
+		const bearerPrefix = "Bearer "
+		if !strings.HasPrefix(authHeader, bearerPrefix) {
+			utils.WriteJSONError(w, "Invalid authorization header", http.StatusUnauthorized)
+			return
+		}
+
+		tokenString := strings.TrimSpace(strings.TrimPrefix(authHeader, bearerPrefix))
+		if tokenString == "" {
+			utils.WriteJSONError(w, "Invalid authorization header", http.StatusUnauthorized)
+			return
+		}
+
+		claims, err := services.ValidateJWT(tokenString)
+		if err != nil {
+			utils.WriteJSONError(w, "Invalid token", http.StatusUnauthorized)
+			return
+		}
+
+		userID, ok := services.UserIDFromClaims(claims)
+		if !ok {
+			utils.WriteJSONError(w, "Invalid token", http.StatusUnauthorized)
+			return
+		}
+
+		ctx := context.WithValue(r.Context(), userIDContextKey, userID)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+func UserIDFromContext(ctx context.Context) (int, bool) {
+	userID, ok := ctx.Value(userIDContextKey).(int)
+	return userID, ok
+}

--- a/backend/internal/middleware/auth_middleware_test.go
+++ b/backend/internal/middleware/auth_middleware_test.go
@@ -1,0 +1,79 @@
+package middleware
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"sharex-backend/internal/services"
+)
+
+func TestAuthMiddleware_MissingToken(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	rr := httptest.NewRecorder()
+
+	handler := AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("Expected status 401, got %d", rr.Code)
+	}
+}
+
+func TestAuthMiddleware_InvalidToken(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer invalid-token")
+	rr := httptest.NewRecorder()
+
+	handler := AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("Expected status 401, got %d", rr.Code)
+	}
+}
+
+func TestAuthMiddleware_ValidTokenSetsUserIDInContext(t *testing.T) {
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	token, err := services.GenerateJWT(42, "test@example.com", "Test User")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/protected", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler := AuthMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userID, ok := UserIDFromContext(r.Context())
+		if !ok {
+			t.Fatalf("Expected user ID in request context")
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]int{"userID": userID})
+	}))
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", rr.Code)
+	}
+
+	var response map[string]int
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Expected valid JSON response: %v", err)
+	}
+
+	if response["userID"] != 42 {
+		t.Fatalf("Expected userID 42, got %d", response["userID"])
+	}
+}

--- a/backend/internal/services/jwt.go
+++ b/backend/internal/services/jwt.go
@@ -1,7 +1,9 @@
 package services
 
 import (
+	"fmt"
 	"os"
+	"strconv"
 	"time"
 
 	"github.com/golang-jwt/jwt/v5"
@@ -24,4 +26,50 @@ func GenerateJWT(userID int, email string, name string) (string, error) {
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	return token.SignedString([]byte(secret))
+}
+
+func ValidateJWT(tokenString string) (jwt.MapClaims, error) {
+	secret := os.Getenv("JWT_SECRET")
+	if secret == "" {
+		secret = "dev-secret-change-me"
+	}
+
+	parsedToken, err := jwt.Parse(tokenString, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		return []byte(secret), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	claims, ok := parsedToken.Claims.(jwt.MapClaims)
+	if !ok || !parsedToken.Valid {
+		return nil, fmt.Errorf("invalid token claims")
+	}
+
+	return claims, nil
+}
+
+func UserIDFromClaims(claims jwt.MapClaims) (int, bool) {
+	sub, ok := claims["sub"]
+	if !ok {
+		return 0, false
+	}
+
+	switch v := sub.(type) {
+	case float64:
+		return int(v), true
+	case int:
+		return v, true
+	case string:
+		parsed, err := strconv.Atoi(v)
+		if err != nil {
+			return 0, false
+		}
+		return parsed, true
+	default:
+		return 0, false
+	}
 }


### PR DESCRIPTION
This PR introduces JWT-based authentication middleware to secure protected backend routes. The middleware validates incoming JWT tokens and attaches authenticated user information to the request context for use in downstream handlers.

Changes Made:

Implemented JWT authentication middleware
Extracts token from Authorization header (Bearer token)
Validates token signature and expiration
Parses token to retrieve user information (e.g., user ID)
Attaches user ID to request context for use in handlers
Returns 401 Unauthorized response for missing, invalid, or expired tokens

Acceptance Criteria:

Protected routes require a valid token
Invalid or missing token returns 401
User ID is available to handlers via request context