### PR TITLE
BE3-05: associate uploaded files with owner user ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,13 @@ Invalid credentials response (`401 Unauthorized`):
 }
 ```
 
+`POST /upload`
+
+Design choice for Sprint 3:
+1. Upload is a protected route and requires a valid JWT in `Authorization: Bearer <token>`.
+2. Anonymous uploads are explicitly rejected with `401 Unauthorized`.
+3. Authenticated uploads are associated with the authenticated user via `files.owner_id`.
+
 ### Frontend
 
 ```bash

--- a/backend/db/schema/files_add_owner.sql
+++ b/backend/db/schema/files_add_owner.sql
@@ -1,0 +1,3 @@
+-- Add optional owner reference for file uploads
+ALTER TABLE files
+ADD COLUMN IF NOT EXISTS owner_id INTEGER REFERENCES users(id) ON DELETE SET NULL;

--- a/backend/internal/handlers/upload_handler.go
+++ b/backend/internal/handlers/upload_handler.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"sharex-backend/internal/middleware"
 	"sharex-backend/internal/models"
 	"sharex-backend/internal/repository"
 	"sharex-backend/internal/utils"
@@ -65,11 +66,17 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 
 	repo := repository.FileRepository{}
 
+	var ownerID *int
+	if uid, ok := middleware.UserIDFromContext(r.Context()); ok {
+		ownerID = &uid
+	}
+
 	newFile := models.File{
 		Filename: handler.Filename,
 		Filepath: fp,
 		Token:    token,
 		Size:     size,
+		OwnerID:  ownerID,
 	}
 
 	err = repo.Create(&newFile)

--- a/backend/internal/handlers/upload_handler_test.go
+++ b/backend/internal/handlers/upload_handler_test.go
@@ -10,7 +10,9 @@ import (
 	"path/filepath"
 	"testing"
 
+	"sharex-backend/internal/middleware"
 	"sharex-backend/internal/repository"
+	"sharex-backend/internal/services"
 )
 
 func TestUploadHandler_MissingFile(t *testing.T) {
@@ -112,5 +114,56 @@ func TestUploadHandler_ValidFile(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Clean(fileMeta.Filepath)); err != nil {
 		t.Fatalf("Expected uploaded file to exist on disk: %v", err)
+	}
+}
+
+func TestUploadHandler_AuthenticatedUploadStoresOwnerID(t *testing.T) {
+	repository.ResetInMemoryStore()
+	t.Cleanup(func() {
+		os.RemoveAll("uploads")
+	})
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	authToken, err := services.GenerateJWT(77, "owner@example.com", "Owner")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	fw, err := writer.CreateFormFile("file", "owner-test.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fw.Write([]byte("owner content"))
+	writer.Close()
+
+	req, err := http.NewRequest("POST", "/upload", &buf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer "+authToken)
+
+	rr := httptest.NewRecorder()
+	handler := middleware.AuthMiddleware(http.HandlerFunc(UploadHandler))
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %v", rr.Code)
+	}
+
+	var response map[string]string
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Expected valid JSON response: %v", err)
+	}
+
+	fileMeta, err := (&repository.FileRepository{}).GetByToken(response["token"])
+	if err != nil {
+		t.Fatalf("Expected file metadata to be saved: %v", err)
+	}
+
+	if fileMeta.OwnerID == nil || *fileMeta.OwnerID != 77 {
+		t.Fatalf("Expected owner ID 77, got %v", fileMeta.OwnerID)
 	}
 }

--- a/backend/internal/models/file.go
+++ b/backend/internal/models/file.go
@@ -8,5 +8,6 @@ type File struct {
 	Filepath  string
 	Token     string
 	Size      int64
+	OwnerID   *int
 	CreatedAt time.Time
 }

--- a/backend/internal/repository/file_repository.go
+++ b/backend/internal/repository/file_repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"database/sql"
 	"errors"
 	"sync"
 	"time"
@@ -33,8 +34,8 @@ func (r *FileRepository) Create(file *models.File) error {
 	}
 
 	query := `
-	INSERT INTO files (filename, filepath, token, size)
-	VALUES ($1, $2, $3, $4)
+	INSERT INTO files (filename, filepath, token, size, owner_id)
+	VALUES ($1, $2, $3, $4, $5)
 	RETURNING id, created_at
 	`
 
@@ -46,6 +47,7 @@ func (r *FileRepository) Create(file *models.File) error {
 		file.Filepath,
 		file.Token,
 		file.Size,
+		file.OwnerID,
 	).Scan(&file.ID, &file.CreatedAt)
 }
 
@@ -64,7 +66,7 @@ func (r *FileRepository) GetByToken(token string) (*models.File, error) {
 	}
 
 	query := `
-	SELECT id, filename, filepath, token, size, created_at
+	SELECT id, filename, filepath, token, size, owner_id, created_at
 	FROM files
 	WHERE token = $1
 	`
@@ -73,6 +75,7 @@ func (r *FileRepository) GetByToken(token string) (*models.File, error) {
 	defer cancel()
 
 	var file models.File
+	var ownerID sql.NullInt64
 
 	err := database.DB.QueryRow(ctx, query, token).Scan(
 		&file.ID,
@@ -80,11 +83,17 @@ func (r *FileRepository) GetByToken(token string) (*models.File, error) {
 		&file.Filepath,
 		&file.Token,
 		&file.Size,
+		&ownerID,
 		&file.CreatedAt,
 	)
 
 	if err != nil {
 		return nil, err
+	}
+
+	if ownerID.Valid {
+		id := int(ownerID.Int64)
+		file.OwnerID = &id
 	}
 
 	return &file, nil


### PR DESCRIPTION
This PR extends the file metadata model to associate uploaded files with a registered user. It enables tracking file ownership and supports future features such as user-specific file management and access control.

Changes Made:

Updated files table schema to include owner user ID reference
Modified upload handler to store authenticated user ID when uploading files
Integrated JWT middleware context to retrieve user ID during upload
Defined behavior for unauthenticated uploads (supported or restricted based on design)
Ensured backward compatibility with existing file records where applicable

Acceptance Criteria:

Files table includes owner reference
Authenticated uploads store owner user ID
Anonymous uploads are either supported or explicitly rejected based on chosen design