### PR TITLE
BE3-06: add protected /me endpoint

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -47,6 +47,7 @@ func main() {
 
 	mux.HandleFunc("/auth/register", handlers.RegisterHandler)
 	mux.HandleFunc("/auth/login", handlers.LoginHandler)
+	mux.Handle("/me", middleware.AuthMiddleware(http.HandlerFunc(handlers.MeHandler)))
 
 	log.Printf("Server running on port %s\n", port)
 

--- a/backend/internal/handlers/auth_handler.go
+++ b/backend/internal/handlers/auth_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strings"
 
+	"sharex-backend/internal/middleware"
 	"sharex-backend/internal/models"
 	"sharex-backend/internal/repository"
 	"sharex-backend/internal/services"
@@ -123,6 +124,36 @@ func LoginHandler(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(map[string]any{
 		"message": "Login successful",
 		"token":   token,
+		"user": map[string]any{
+			"id":    user.ID,
+			"name":  user.Name,
+			"email": user.Email,
+		},
+	})
+}
+
+func MeHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		utils.WriteJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userID, ok := middleware.UserIDFromContext(r.Context())
+	if !ok {
+		utils.WriteJSONError(w, "Invalid token", http.StatusUnauthorized)
+		return
+	}
+
+	repo := repository.UserRepository{}
+	user, err := repo.GetByID(userID)
+	if err != nil {
+		utils.WriteJSONError(w, "Invalid token", http.StatusUnauthorized)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]any{
 		"user": map[string]any{
 			"id":    user.ID,
 			"name":  user.Name,

--- a/backend/internal/handlers/auth_handler_test.go
+++ b/backend/internal/handlers/auth_handler_test.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"testing"
 
+	"sharex-backend/internal/middleware"
 	"sharex-backend/internal/models"
 	"sharex-backend/internal/repository"
 	"sharex-backend/internal/services"
@@ -170,6 +171,66 @@ func TestLoginHandler_InvalidCredentials(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	http.HandlerFunc(LoginHandler).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("Expected status 401, got %d", rr.Code)
+	}
+}
+
+func TestMeHandler_ReturnsAuthenticatedUser(t *testing.T) {
+	repository.ResetInMemoryUserStore()
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	hash, err := services.HashPassword("pass12345")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := repository.UserRepository{}
+	user := &models.User{Name: "Profile User", Email: "profile@example.com", PasswordHash: hash}
+	if err := repo.Create(user); err != nil {
+		t.Fatal(err)
+	}
+
+	token, err := services.GenerateJWT(user.ID, user.Email, user.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/me", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler := middleware.AuthMiddleware(http.HandlerFunc(MeHandler))
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", rr.Code)
+	}
+
+	var response struct {
+		User struct {
+			ID    int    `json:"id"`
+			Name  string `json:"name"`
+			Email string `json:"email"`
+		} `json:"user"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Expected valid JSON response: %v", err)
+	}
+
+	if response.User.ID != user.ID || response.User.Name != user.Name || response.User.Email != user.Email {
+		t.Fatalf("Expected user profile to match authenticated user")
+	}
+}
+
+func TestMeHandler_InvalidTokenReturnsUnauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/me", nil)
+	req.Header.Set("Authorization", "Bearer invalid-token")
+	rr := httptest.NewRecorder()
+
+	handler := middleware.AuthMiddleware(http.HandlerFunc(MeHandler))
+	handler.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusUnauthorized {
 		t.Fatalf("Expected status 401, got %d", rr.Code)

--- a/backend/internal/repository/user_repository.go
+++ b/backend/internal/repository/user_repository.go
@@ -116,6 +116,46 @@ func (r *UserRepository) GetByEmail(email string) (*models.User, error) {
 	return &user, nil
 }
 
+func (r *UserRepository) GetByID(id int) (*models.User, error) {
+	if database.DB == nil {
+		inMemoryUsersMu.RLock()
+		defer inMemoryUsersMu.RUnlock()
+
+		for _, user := range inMemoryUsers {
+			if user.ID == id {
+				userCopy := *user
+				return &userCopy, nil
+			}
+		}
+
+		return nil, errors.New("user not found")
+	}
+
+	query := `
+	SELECT id, name, email, password_hash, created_at
+	FROM users
+	WHERE id = $1
+	`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var user models.User
+
+	err := database.DB.QueryRow(ctx, query, id).Scan(
+		&user.ID,
+		&user.Name,
+		&user.Email,
+		&user.PasswordHash,
+		&user.CreatedAt,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &user, nil
+}
+
 func ResetInMemoryUserStore() {
 	inMemoryUsersMu.Lock()
 	defer inMemoryUsersMu.Unlock()


### PR DESCRIPTION
This PR adds a protected endpoint to retrieve the profile of the currently authenticated user. It uses the JWT authentication middleware to identify the user and returns basic user details.

Changes Made:

Added GET /me endpoint
Integrated JWT middleware to protect the route
Extracted user ID from request context
Fetched user details from database using user ID
Returned user profile including id, name, and email
Handled unauthorized access for missing or invalid tokens

Acceptance Criteria:

Endpoint requires valid JWT
Returns user id, name, and email
Invalid or missing token returns 401