### PR TITLE
BE3-07: add protected /me/files endpoint

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -48,6 +48,7 @@ func main() {
 	mux.HandleFunc("/auth/register", handlers.RegisterHandler)
 	mux.HandleFunc("/auth/login", handlers.LoginHandler)
 	mux.Handle("/me", middleware.AuthMiddleware(http.HandlerFunc(handlers.MeHandler)))
+	mux.Handle("/me/files", middleware.AuthMiddleware(http.HandlerFunc(handlers.MyFilesHandler)))
 
 	log.Printf("Server running on port %s\n", port)
 

--- a/backend/internal/handlers/auth_handler.go
+++ b/backend/internal/handlers/auth_handler.go
@@ -161,3 +161,40 @@ func MeHandler(w http.ResponseWriter, r *http.Request) {
 		},
 	})
 }
+
+func MyFilesHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		utils.WriteJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userID, ok := middleware.UserIDFromContext(r.Context())
+	if !ok {
+		utils.WriteJSONError(w, "Invalid token", http.StatusUnauthorized)
+		return
+	}
+
+	repo := repository.FileRepository{}
+	files, err := repo.ListByOwnerID(userID)
+	if err != nil {
+		utils.WriteJSONError(w, "Database error", http.StatusInternalServerError)
+		return
+	}
+
+	items := make([]map[string]any, 0, len(files))
+	for _, file := range files {
+		items = append(items, map[string]any{
+			"id":        file.ID,
+			"filename":  file.Filename,
+			"token":     file.Token,
+			"size":      file.Size,
+			"createdAt": file.CreatedAt,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]any{
+		"files": items,
+	})
+}

--- a/backend/internal/handlers/auth_handler_test.go
+++ b/backend/internal/handlers/auth_handler_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"testing"
+	"time"
 
 	"sharex-backend/internal/middleware"
 	"sharex-backend/internal/models"
@@ -230,6 +231,99 @@ func TestMeHandler_InvalidTokenReturnsUnauthorized(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	handler := middleware.AuthMiddleware(http.HandlerFunc(MeHandler))
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("Expected status 401, got %d", rr.Code)
+	}
+}
+
+func TestMyFilesHandler_ReturnsAuthenticatedUsersFiles(t *testing.T) {
+	repository.ResetInMemoryStore()
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	userID := 101
+	otherUserID := 202
+
+	repo := repository.FileRepository{}
+	err := repo.Create(&models.File{
+		Filename:  "mine-1.txt",
+		Filepath:  "/tmp/mine-1.txt",
+		Token:     "mine-token-1",
+		Size:      10,
+		OwnerID:   &userID,
+		CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = repo.Create(&models.File{
+		Filename:  "mine-2.txt",
+		Filepath:  "/tmp/mine-2.txt",
+		Token:     "mine-token-2",
+		Size:      20,
+		OwnerID:   &userID,
+		CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = repo.Create(&models.File{
+		Filename:  "others.txt",
+		Filepath:  "/tmp/others.txt",
+		Token:     "other-token",
+		Size:      30,
+		OwnerID:   &otherUserID,
+		CreatedAt: time.Now(),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	token, err := services.GenerateJWT(userID, "me@example.com", "Me")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/me/files", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler := middleware.AuthMiddleware(http.HandlerFunc(MyFilesHandler))
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", rr.Code)
+	}
+
+	var response struct {
+		Files []struct {
+			Token string `json:"token"`
+		} `json:"files"`
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &response); err != nil {
+		t.Fatalf("Expected valid JSON response: %v", err)
+	}
+
+	if len(response.Files) != 2 {
+		t.Fatalf("Expected 2 files, got %d", len(response.Files))
+	}
+
+	for _, f := range response.Files {
+		if f.Token == "other-token" {
+			t.Fatalf("Expected only authenticated user's files")
+		}
+	}
+}
+
+func TestMyFilesHandler_InvalidTokenReturnsUnauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/me/files", nil)
+	req.Header.Set("Authorization", "Bearer invalid-token")
+	rr := httptest.NewRecorder()
+
+	handler := middleware.AuthMiddleware(http.HandlerFunc(MyFilesHandler))
 	handler.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusUnauthorized {

--- a/backend/internal/repository/file_repository.go
+++ b/backend/internal/repository/file_repository.go
@@ -99,6 +99,72 @@ func (r *FileRepository) GetByToken(token string) (*models.File, error) {
 	return &file, nil
 }
 
+func (r *FileRepository) ListByOwnerID(ownerID int) ([]models.File, error) {
+	if database.DB == nil {
+		inMemoryMu.RLock()
+		defer inMemoryMu.RUnlock()
+
+		files := make([]models.File, 0)
+		for _, file := range inMemoryFiles {
+			if file.OwnerID == nil || *file.OwnerID != ownerID {
+				continue
+			}
+
+			fileCopy := *file
+			files = append(files, fileCopy)
+		}
+
+		return files, nil
+	}
+
+	query := `
+	SELECT id, filename, filepath, token, size, owner_id, created_at
+	FROM files
+	WHERE owner_id = $1
+	ORDER BY created_at DESC
+	`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	rows, err := database.DB.Query(ctx, query, ownerID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	files := make([]models.File, 0)
+	for rows.Next() {
+		var file models.File
+		var owner sql.NullInt64
+
+		if err := rows.Scan(
+			&file.ID,
+			&file.Filename,
+			&file.Filepath,
+			&file.Token,
+			&file.Size,
+			&owner,
+			&file.CreatedAt,
+		); err != nil {
+			return nil, err
+		}
+
+		if owner.Valid {
+			id := int(owner.Int64)
+			file.OwnerID = &id
+		}
+
+		files = append(files, file)
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	return files, nil
+}
+
 func ResetInMemoryStore() {
 	inMemoryMu.Lock()
 	defer inMemoryMu.Unlock()


### PR DESCRIPTION
This PR adds a protected endpoint to fetch the list of files uploaded by the currently authenticated user. It uses the JWT middleware to identify the user and returns only the files associated with that user.

Changes Made:

Added GET /me/files endpoint
Protected route using JWT authentication middleware
Retrieved user ID from request context
Queried database to fetch files belonging to the authenticated user
Returned file metadata including filename, token, size, and createdAt
Handled unauthorized access for invalid or missing tokens

Acceptance Criteria:

Endpoint requires valid JWT
Returns only current user’s files
Includes filename, token, size, and createdAt in response