### PR TITLE
BE3-08: add protected delete endpoint for user files

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -49,6 +49,7 @@ func main() {
 	mux.HandleFunc("/auth/login", handlers.LoginHandler)
 	mux.Handle("/me", middleware.AuthMiddleware(http.HandlerFunc(handlers.MeHandler)))
 	mux.Handle("/me/files", middleware.AuthMiddleware(http.HandlerFunc(handlers.MyFilesHandler)))
+	mux.Handle("/me/files/", middleware.AuthMiddleware(http.HandlerFunc(handlers.DeleteMyFileHandler)))
 
 	log.Printf("Server running on port %s\n", port)
 

--- a/backend/internal/handlers/auth_handler.go
+++ b/backend/internal/handlers/auth_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"os"
 	"strings"
 
 	"sharex-backend/internal/middleware"
@@ -196,5 +197,57 @@ func MyFilesHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]any{
 		"files": items,
+	})
+}
+
+func DeleteMyFileHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodDelete {
+		utils.WriteJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userID, ok := middleware.UserIDFromContext(r.Context())
+	if !ok {
+		utils.WriteJSONError(w, "Invalid token", http.StatusUnauthorized)
+		return
+	}
+
+	token := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/me/files/"))
+	if token == "" || strings.Contains(token, "/") {
+		utils.WriteJSONError(w, "Invalid token", http.StatusBadRequest)
+		return
+	}
+
+	repo := repository.FileRepository{}
+	file, err := repo.GetByToken(token)
+	if err != nil {
+		utils.WriteJSONError(w, "File not found", http.StatusNotFound)
+		return
+	}
+
+	if file.OwnerID == nil || *file.OwnerID != userID {
+		utils.WriteJSONError(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	if err := os.Remove(file.Filepath); err != nil {
+		if os.IsNotExist(err) {
+			utils.WriteJSONError(w, "File not found", http.StatusNotFound)
+			return
+		}
+
+		utils.WriteJSONError(w, "Unable to delete file", http.StatusInternalServerError)
+		return
+	}
+
+	if err := repo.DeleteByToken(token); err != nil {
+		utils.WriteJSONError(w, "File not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{
+		"message": "File deleted successfully",
 	})
 }

--- a/backend/internal/handlers/auth_handler_test.go
+++ b/backend/internal/handlers/auth_handler_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -324,6 +325,129 @@ func TestMyFilesHandler_InvalidTokenReturnsUnauthorized(t *testing.T) {
 	rr := httptest.NewRecorder()
 
 	handler := middleware.AuthMiddleware(http.HandlerFunc(MyFilesHandler))
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("Expected status 401, got %d", rr.Code)
+	}
+}
+
+func TestDeleteMyFileHandler_Success(t *testing.T) {
+	repository.ResetInMemoryStore()
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	userID := 303
+	token, err := services.GenerateJWT(userID, "owner@example.com", "Owner")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "owned-file.txt")
+	if err := os.WriteFile(filePath, []byte("delete me"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := repository.FileRepository{}
+	if err := repo.Create(&models.File{
+		Filename:  "owned-file.txt",
+		Filepath:  filePath,
+		Token:     "owned-delete-token",
+		Size:      9,
+		OwnerID:   &userID,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/me/files/owned-delete-token", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler := middleware.AuthMiddleware(http.HandlerFunc(DeleteMyFileHandler))
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", rr.Code)
+	}
+
+	if _, err := os.Stat(filePath); !os.IsNotExist(err) {
+		t.Fatalf("Expected physical file to be deleted")
+	}
+
+	if _, err := repo.GetByToken("owned-delete-token"); err == nil {
+		t.Fatalf("Expected metadata to be deleted")
+	}
+}
+
+func TestDeleteMyFileHandler_ForbiddenForNonOwner(t *testing.T) {
+	repository.ResetInMemoryStore()
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	ownerID := 404
+	nonOwnerID := 505
+	token, err := services.GenerateJWT(nonOwnerID, "nonowner@example.com", "NonOwner")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tempDir := t.TempDir()
+	filePath := filepath.Join(tempDir, "owner-only.txt")
+	if err := os.WriteFile(filePath, []byte("do not delete"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := repository.FileRepository{}
+	if err := repo.Create(&models.File{
+		Filename:  "owner-only.txt",
+		Filepath:  filePath,
+		Token:     "forbidden-token",
+		Size:      13,
+		OwnerID:   &ownerID,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/me/files/forbidden-token", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler := middleware.AuthMiddleware(http.HandlerFunc(DeleteMyFileHandler))
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("Expected status 403, got %d", rr.Code)
+	}
+}
+
+func TestDeleteMyFileHandler_NotFound(t *testing.T) {
+	repository.ResetInMemoryStore()
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	token, err := services.GenerateJWT(606, "user@example.com", "User")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodDelete, "/me/files/missing-token", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler := middleware.AuthMiddleware(http.HandlerFunc(DeleteMyFileHandler))
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("Expected status 404, got %d", rr.Code)
+	}
+}
+
+func TestDeleteMyFileHandler_InvalidTokenReturnsUnauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodDelete, "/me/files/any-token", nil)
+	req.Header.Set("Authorization", "Bearer invalid-token")
+	rr := httptest.NewRecorder()
+
+	handler := middleware.AuthMiddleware(http.HandlerFunc(DeleteMyFileHandler))
 	handler.ServeHTTP(rr, req)
 
 	if rr.Code != http.StatusUnauthorized {

--- a/backend/internal/repository/file_repository.go
+++ b/backend/internal/repository/file_repository.go
@@ -165,6 +165,39 @@ func (r *FileRepository) ListByOwnerID(ownerID int) ([]models.File, error) {
 	return files, nil
 }
 
+func (r *FileRepository) DeleteByToken(token string) error {
+	if database.DB == nil {
+		inMemoryMu.Lock()
+		defer inMemoryMu.Unlock()
+
+		if _, ok := inMemoryFiles[token]; !ok {
+			return errors.New("file not found")
+		}
+
+		delete(inMemoryFiles, token)
+		return nil
+	}
+
+	query := `
+	DELETE FROM files
+	WHERE token = $1
+	`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := database.DB.Exec(ctx, query, token)
+	if err != nil {
+		return err
+	}
+
+	if result.RowsAffected() == 0 {
+		return errors.New("file not found")
+	}
+
+	return nil
+}
+
 func ResetInMemoryStore() {
 	inMemoryMu.Lock()
 	defer inMemoryMu.Unlock()


### PR DESCRIPTION
 This PR adds a protected endpoint to allow authenticated users to delete their own uploaded files. It ensures that only the owner of a file can delete it and removes both the file metadata and the physical file from storage.

Changes Made:

Added DELETE /me/files/{token} endpoint
Protected route using JWT authentication middleware
Retrieved user ID from request context
Validated file ownership before deletion
Deleted file metadata from database
Removed physical file from storage
Handled error cases for unauthorized access and missing files

Acceptance Criteria:

Endpoint requires valid JWT
Only file owner can delete the file
Deletes both metadata and physical file
Returns 403 for unauthorized access and 404 if file not found