### PR TITLE
BE3-09: add file revoke support for owners

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -49,6 +49,7 @@ func main() {
 	mux.HandleFunc("/auth/login", handlers.LoginHandler)
 	mux.Handle("/me", middleware.AuthMiddleware(http.HandlerFunc(handlers.MeHandler)))
 	mux.Handle("/me/files", middleware.AuthMiddleware(http.HandlerFunc(handlers.MyFilesHandler)))
+	mux.Handle("/me/files/revoke/", middleware.AuthMiddleware(http.HandlerFunc(handlers.RevokeMyFileHandler)))
 	mux.Handle("/me/files/", middleware.AuthMiddleware(http.HandlerFunc(handlers.DeleteMyFileHandler)))
 
 	log.Printf("Server running on port %s\n", port)

--- a/backend/db/schema/files_add_is_active.sql
+++ b/backend/db/schema/files_add_is_active.sql
@@ -1,0 +1,3 @@
+-- Add active flag so links can be revoked without deleting records
+ALTER TABLE files
+ADD COLUMN IF NOT EXISTS is_active BOOLEAN NOT NULL DEFAULT TRUE;

--- a/backend/internal/handlers/auth_handler.go
+++ b/backend/internal/handlers/auth_handler.go
@@ -189,6 +189,7 @@ func MyFilesHandler(w http.ResponseWriter, r *http.Request) {
 			"filename":  file.Filename,
 			"token":     file.Token,
 			"size":      file.Size,
+			"isActive":  file.IsActive,
 			"createdAt": file.CreatedAt,
 		})
 	}
@@ -249,5 +250,47 @@ func DeleteMyFileHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	json.NewEncoder(w).Encode(map[string]string{
 		"message": "File deleted successfully",
+	})
+}
+
+func RevokeMyFileHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPatch {
+		utils.WriteJSONError(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	userID, ok := middleware.UserIDFromContext(r.Context())
+	if !ok {
+		utils.WriteJSONError(w, "Invalid token", http.StatusUnauthorized)
+		return
+	}
+
+	token := strings.TrimSpace(strings.TrimPrefix(r.URL.Path, "/me/files/revoke/"))
+	if token == "" || strings.Contains(token, "/") {
+		utils.WriteJSONError(w, "Invalid token", http.StatusBadRequest)
+		return
+	}
+
+	repo := repository.FileRepository{}
+	file, err := repo.GetByToken(token)
+	if err != nil {
+		utils.WriteJSONError(w, "File not found", http.StatusNotFound)
+		return
+	}
+
+	if file.OwnerID == nil || *file.OwnerID != userID {
+		utils.WriteJSONError(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	if err := repo.RevokeByToken(token); err != nil {
+		utils.WriteJSONError(w, "File not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	json.NewEncoder(w).Encode(map[string]string{
+		"message": "File link revoked successfully",
 	})
 }

--- a/backend/internal/handlers/auth_handler_test.go
+++ b/backend/internal/handlers/auth_handler_test.go
@@ -454,3 +454,94 @@ func TestDeleteMyFileHandler_InvalidTokenReturnsUnauthorized(t *testing.T) {
 		t.Fatalf("Expected status 401, got %d", rr.Code)
 	}
 }
+
+func TestRevokeMyFileHandler_Success(t *testing.T) {
+	repository.ResetInMemoryStore()
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	userID := 707
+	token, err := services.GenerateJWT(userID, "owner@example.com", "Owner")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := repository.FileRepository{}
+	if err := repo.Create(&models.File{
+		Filename:  "revoke-me.txt",
+		Filepath:  "/tmp/revoke-me.txt",
+		Token:     "revoke-token",
+		Size:      10,
+		OwnerID:   &userID,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPatch, "/me/files/revoke/revoke-token", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler := middleware.AuthMiddleware(http.HandlerFunc(RevokeMyFileHandler))
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("Expected status 200, got %d", rr.Code)
+	}
+
+	updated, err := repo.GetByToken("revoke-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if updated.IsActive {
+		t.Fatalf("Expected file to be revoked")
+	}
+}
+
+func TestRevokeMyFileHandler_ForbiddenForNonOwner(t *testing.T) {
+	repository.ResetInMemoryStore()
+	t.Setenv("JWT_SECRET", "test-secret")
+
+	ownerID := 808
+	nonOwnerID := 909
+	token, err := services.GenerateJWT(nonOwnerID, "nonowner@example.com", "NonOwner")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := repository.FileRepository{}
+	if err := repo.Create(&models.File{
+		Filename:  "owner-file.txt",
+		Filepath:  "/tmp/owner-file.txt",
+		Token:     "owner-revoke-token",
+		Size:      8,
+		OwnerID:   &ownerID,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodPatch, "/me/files/revoke/owner-revoke-token", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	rr := httptest.NewRecorder()
+
+	handler := middleware.AuthMiddleware(http.HandlerFunc(RevokeMyFileHandler))
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("Expected status 403, got %d", rr.Code)
+	}
+}
+
+func TestRevokeMyFileHandler_InvalidTokenReturnsUnauthorized(t *testing.T) {
+	req := httptest.NewRequest(http.MethodPatch, "/me/files/revoke/any-token", nil)
+	req.Header.Set("Authorization", "Bearer invalid-token")
+	rr := httptest.NewRecorder()
+
+	handler := middleware.AuthMiddleware(http.HandlerFunc(RevokeMyFileHandler))
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusUnauthorized {
+		t.Fatalf("Expected status 401, got %d", rr.Code)
+	}
+}

--- a/backend/internal/handlers/download_handler.go
+++ b/backend/internal/handlers/download_handler.go
@@ -30,6 +30,11 @@ func DownloadHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if !fileMeta.IsActive {
+		utils.WriteJSONError(w, "File not found", http.StatusNotFound)
+		return
+	}
+
 	file, err := os.Open(fileMeta.Filepath)
 	if err != nil {
 		utils.WriteJSONError(w, "File missing on server", http.StatusNotFound)

--- a/backend/internal/handlers/download_handler_test.go
+++ b/backend/internal/handlers/download_handler_test.go
@@ -106,3 +106,44 @@ func TestDownloadHandler_ReturnsStoredFile(t *testing.T) {
 		t.Fatalf("Expected downloaded content, got %q", body)
 	}
 }
+
+func TestDownloadHandler_RevokedFileCannotBeDownloaded(t *testing.T) {
+	repository.ResetInMemoryStore()
+
+	testFile, err := os.CreateTemp("", "sharex-revoked-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(testFile.Name())
+
+	if _, err := testFile.WriteString("revoked content"); err != nil {
+		t.Fatal(err)
+	}
+	if err := testFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	repo := &repository.FileRepository{}
+	err = repo.Create(&models.File{
+		Filename: "revoked.txt",
+		Filepath: testFile.Name(),
+		Token:    "revoked-token",
+		Size:     int64(len("revoked content")),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := repo.RevokeByToken("revoked-token"); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/download/revoked-token", nil)
+	rr := httptest.NewRecorder()
+
+	http.HandlerFunc(DownloadHandler).ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("Expected 404 for revoked file, got %d", rr.Code)
+	}
+}

--- a/backend/internal/handlers/upload_handler.go
+++ b/backend/internal/handlers/upload_handler.go
@@ -77,6 +77,7 @@ func UploadHandler(w http.ResponseWriter, r *http.Request) {
 		Token:    token,
 		Size:     size,
 		OwnerID:  ownerID,
+		IsActive: true,
 	}
 
 	err = repo.Create(&newFile)

--- a/backend/internal/models/file.go
+++ b/backend/internal/models/file.go
@@ -9,5 +9,6 @@ type File struct {
 	Token     string
 	Size      int64
 	OwnerID   *int
+	IsActive  bool
 	CreatedAt time.Time
 }

--- a/backend/internal/repository/file_repository.go
+++ b/backend/internal/repository/file_repository.go
@@ -20,6 +20,10 @@ var (
 )
 
 func (r *FileRepository) Create(file *models.File) error {
+	if !file.IsActive {
+		file.IsActive = true
+	}
+
 	if database.DB == nil {
 		inMemoryMu.Lock()
 		defer inMemoryMu.Unlock()
@@ -34,8 +38,8 @@ func (r *FileRepository) Create(file *models.File) error {
 	}
 
 	query := `
-	INSERT INTO files (filename, filepath, token, size, owner_id)
-	VALUES ($1, $2, $3, $4, $5)
+	INSERT INTO files (filename, filepath, token, size, owner_id, is_active)
+	VALUES ($1, $2, $3, $4, $5, $6)
 	RETURNING id, created_at
 	`
 
@@ -48,6 +52,7 @@ func (r *FileRepository) Create(file *models.File) error {
 		file.Token,
 		file.Size,
 		file.OwnerID,
+		file.IsActive,
 	).Scan(&file.ID, &file.CreatedAt)
 }
 
@@ -66,7 +71,7 @@ func (r *FileRepository) GetByToken(token string) (*models.File, error) {
 	}
 
 	query := `
-	SELECT id, filename, filepath, token, size, owner_id, created_at
+	SELECT id, filename, filepath, token, size, owner_id, is_active, created_at
 	FROM files
 	WHERE token = $1
 	`
@@ -84,6 +89,7 @@ func (r *FileRepository) GetByToken(token string) (*models.File, error) {
 		&file.Token,
 		&file.Size,
 		&ownerID,
+		&file.IsActive,
 		&file.CreatedAt,
 	)
 
@@ -118,7 +124,7 @@ func (r *FileRepository) ListByOwnerID(ownerID int) ([]models.File, error) {
 	}
 
 	query := `
-	SELECT id, filename, filepath, token, size, owner_id, created_at
+	SELECT id, filename, filepath, token, size, owner_id, is_active, created_at
 	FROM files
 	WHERE owner_id = $1
 	ORDER BY created_at DESC
@@ -145,6 +151,7 @@ func (r *FileRepository) ListByOwnerID(ownerID int) ([]models.File, error) {
 			&file.Token,
 			&file.Size,
 			&owner,
+			&file.IsActive,
 			&file.CreatedAt,
 		); err != nil {
 			return nil, err
@@ -180,6 +187,41 @@ func (r *FileRepository) DeleteByToken(token string) error {
 
 	query := `
 	DELETE FROM files
+	WHERE token = $1
+	`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	result, err := database.DB.Exec(ctx, query, token)
+	if err != nil {
+		return err
+	}
+
+	if result.RowsAffected() == 0 {
+		return errors.New("file not found")
+	}
+
+	return nil
+}
+
+func (r *FileRepository) RevokeByToken(token string) error {
+	if database.DB == nil {
+		inMemoryMu.Lock()
+		defer inMemoryMu.Unlock()
+
+		file, ok := inMemoryFiles[token]
+		if !ok {
+			return errors.New("file not found")
+		}
+
+		file.IsActive = false
+		return nil
+	}
+
+	query := `
+	UPDATE files
+	SET is_active = FALSE
 	WHERE token = $1
 	`
 


### PR DESCRIPTION
This PR adds support for revoking shared file links without deleting the underlying file. It introduces a state flag in the file metadata to mark files as active or revoked, allowing owners to disable access to shared links while retaining the file record.

Changes Made:

Added active/revoked state field to files table
Updated file model to include revocation status
Modified download endpoint to block access for revoked files
Added protected API endpoint for owners to revoke their files
Validated ownership before allowing revoke action
Returned appropriate error response when accessing revoked files

Acceptance Criteria:

File metadata includes active/revoked state
Revoked files cannot be downloaded
Only the owner can revoke file access via protected API