### PR TITLE
FE3-03: Add frontend auth API service

### DIFF
--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -1,0 +1,13 @@
+const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:8080';
+
+async function parseJSON(response) {
+  const data = await response.json().catch(() => ({}));
+
+  if (!response.ok) {
+    throw new Error(data.error || data.message || 'Request failed');
+  }
+
+  return data;
+}
+
+export { API_BASE_URL, parseJSON };

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -10,6 +10,13 @@ async function parseJSON(response) {
   return data;
 }
 
+function getAuthHeaders(token) {
+  return {
+    Accept: 'application/json',
+    Authorization: `Bearer ${token}`,
+  };
+}
+
 async function registerUser(userData) {
   const response = await fetch(`${API_BASE_URL}/auth/register`, {
     method: 'POST',
@@ -36,4 +43,20 @@ async function loginUser(credentials) {
   return parseJSON(response);
 }
 
-export { API_BASE_URL, parseJSON, registerUser, loginUser };
+async function getCurrentUser(token) {
+  const response = await fetch(`${API_BASE_URL}/me`, {
+    method: 'GET',
+    headers: getAuthHeaders(token),
+  });
+
+  return parseJSON(response);
+}
+
+export {
+  API_BASE_URL,
+  parseJSON,
+  getAuthHeaders,
+  registerUser,
+  loginUser,
+  getCurrentUser,
+};

--- a/frontend/src/services/auth.js
+++ b/frontend/src/services/auth.js
@@ -10,4 +10,30 @@ async function parseJSON(response) {
   return data;
 }
 
-export { API_BASE_URL, parseJSON };
+async function registerUser(userData) {
+  const response = await fetch(`${API_BASE_URL}/auth/register`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(userData),
+  });
+
+  return parseJSON(response);
+}
+
+async function loginUser(credentials) {
+  const response = await fetch(`${API_BASE_URL}/auth/login`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(credentials),
+  });
+
+  return parseJSON(response);
+}
+
+export { API_BASE_URL, parseJSON, registerUser, loginUser };


### PR DESCRIPTION
## Description
Added a reusable frontend auth API service for authentication-related requests.

## Changes Made
- Created `frontend/src/services/auth.js`
- Added centralized API base URL and JSON response parsing
- Added `registerUser()` for registration requests
- Added `loginUser()` for login requests
- Added `getCurrentUser()` for authenticated profile requests
- Added `getAuthHeaders()` helper for bearer token requests

## Testing
- Verified service file structure and exported methods
- Confirmed endpoint paths for `/auth/register`, `/auth/login`, and `/me`