### PR TITLE
FE3-04: Add auth context/provider for JWT state

### DIFF
--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -1,0 +1,9 @@
+import { createContext, useContext } from 'react';
+
+const AuthContext = createContext(null);
+
+function useAuth() {
+  return useContext(AuthContext);
+}
+
+export { AuthContext, useAuth };

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -1,11 +1,12 @@
-import { createContext, useContext, useMemo, useState } from 'react';
-import { loginUser, registerUser } from '../services/auth';
+import { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { getCurrentUser, loginUser, registerUser } from '../services/auth';
 
 const AuthContext = createContext(null);
 
 function AuthProvider({ children }) {
   const [token, setToken] = useState(localStorage.getItem('authToken') || '');
   const [currentUser, setCurrentUser] = useState(null);
+  const [isLoading, setIsLoading] = useState(Boolean(localStorage.getItem('authToken')));
 
   async function login(credentials) {
     const data = await loginUser(credentials);
@@ -24,19 +25,45 @@ function AuthProvider({ children }) {
   function logout() {
     setToken('');
     setCurrentUser(null);
+    setIsLoading(false);
     localStorage.removeItem('authToken');
   }
+
+  useEffect(() => {
+    async function loadCurrentUser() {
+      if (!token) {
+        setCurrentUser(null);
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const user = await getCurrentUser(token);
+        setCurrentUser(user);
+      } catch (error) {
+        setToken('');
+        setCurrentUser(null);
+        localStorage.removeItem('authToken');
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    loadCurrentUser();
+  }, [token]);
 
   const value = useMemo(
     () => ({
       token,
       currentUser,
+      isLoading,
       setCurrentUser,
       login,
       register,
       logout,
+      isAuthenticated: Boolean(token),
     }),
-    [token, currentUser]
+    [token, currentUser, isLoading]
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/src/context/AuthContext.js
+++ b/frontend/src/context/AuthContext.js
@@ -1,9 +1,49 @@
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useMemo, useState } from 'react';
+import { loginUser, registerUser } from '../services/auth';
 
 const AuthContext = createContext(null);
+
+function AuthProvider({ children }) {
+  const [token, setToken] = useState(localStorage.getItem('authToken') || '');
+  const [currentUser, setCurrentUser] = useState(null);
+
+  async function login(credentials) {
+    const data = await loginUser(credentials);
+    const authToken = data.token || '';
+
+    setToken(authToken);
+    localStorage.setItem('authToken', authToken);
+
+    return data;
+  }
+
+  async function register(userData) {
+    return registerUser(userData);
+  }
+
+  function logout() {
+    setToken('');
+    setCurrentUser(null);
+    localStorage.removeItem('authToken');
+  }
+
+  const value = useMemo(
+    () => ({
+      token,
+      currentUser,
+      setCurrentUser,
+      login,
+      register,
+      logout,
+    }),
+    [token, currentUser]
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
 
 function useAuth() {
   return useContext(AuthContext);
 }
 
-export { AuthContext, useAuth };
+export { AuthContext, AuthProvider, useAuth };


### PR DESCRIPTION
## Description
Added an auth context/provider to manage JWT session state in the frontend.

## Changes Made
- Created `AuthContext` and `AuthProvider`
- Added token and current user state
- Added `login`, `register`, and `logout` actions
- Added localStorage token persistence
- Added current user loading when a token exists
- Added derived auth state values like `isAuthenticated` and `isLoading`

## Testing
- Verified auth context structure and exports
- Confirmed token persistence logic using localStorage
- Confirmed current user fetch flow uses the shared auth service