### PR TITLE
BE3-14: Added logging middleware across all routes

### DIFF
--- a/backend/cmd/server/main.go
+++ b/backend/cmd/server/main.go
@@ -32,25 +32,54 @@ func main() {
 
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	// Root
+	mux.Handle("/", middleware.LoggingMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte("ShareX Backend Running"))
-	})
+	})))
 
-	mux.HandleFunc("/health", handlers.HealthHandler)
+	// Health
+	mux.Handle("/health", middleware.LoggingMiddleware(http.HandlerFunc(handlers.HealthHandler)))
 
-	mux.Handle("/upload", middleware.AuthMiddleware(http.HandlerFunc(handlers.UploadHandler)))
+	// Upload (Auth + Logging)
+	mux.Handle("/upload",
+		middleware.LoggingMiddleware(
+			middleware.AuthMiddleware(http.HandlerFunc(handlers.UploadHandler)),
+		),
+	)
 
-	mux.HandleFunc("/download/", handlers.DownloadHandler)
+	// Public routes
+	mux.Handle("/download/", middleware.LoggingMiddleware(http.HandlerFunc(handlers.DownloadHandler)))
+	mux.Handle("/file/", middleware.LoggingMiddleware(http.HandlerFunc(handlers.MetadataHandler)))
 
-	mux.HandleFunc("/file/", handlers.MetadataHandler)
+	// Auth routes
+	mux.Handle("/auth/register", middleware.LoggingMiddleware(http.HandlerFunc(handlers.RegisterHandler)))
+	mux.Handle("/auth/login", middleware.LoggingMiddleware(http.HandlerFunc(handlers.LoginHandler)))
 
-	mux.HandleFunc("/auth/register", handlers.RegisterHandler)
-	mux.HandleFunc("/auth/login", handlers.LoginHandler)
-	mux.Handle("/me", middleware.AuthMiddleware(http.HandlerFunc(handlers.MeHandler)))
-	mux.Handle("/me/files", middleware.AuthMiddleware(http.HandlerFunc(handlers.MyFilesHandler)))
-	mux.Handle("/me/files/revoke/", middleware.AuthMiddleware(http.HandlerFunc(handlers.RevokeMyFileHandler)))
-	mux.Handle("/me/files/", middleware.AuthMiddleware(http.HandlerFunc(handlers.DeleteMyFileHandler)))
+	// Protected routes (Auth + Logging)
+	mux.Handle("/me",
+		middleware.LoggingMiddleware(
+			middleware.AuthMiddleware(http.HandlerFunc(handlers.MeHandler)),
+		),
+	)
+
+	mux.Handle("/me/files",
+		middleware.LoggingMiddleware(
+			middleware.AuthMiddleware(http.HandlerFunc(handlers.MyFilesHandler)),
+		),
+	)
+
+	mux.Handle("/me/files/revoke/",
+		middleware.LoggingMiddleware(
+			middleware.AuthMiddleware(http.HandlerFunc(handlers.RevokeMyFileHandler)),
+		),
+	)
+
+	mux.Handle("/me/files/",
+		middleware.LoggingMiddleware(
+			middleware.AuthMiddleware(http.HandlerFunc(handlers.DeleteMyFileHandler)),
+		),
+	)
 
 	log.Printf("Server running on port %s\n", port)
 

--- a/backend/internal/middleware/logging.go
+++ b/backend/internal/middleware/logging.go
@@ -1,0 +1,42 @@
+package middleware
+
+import (
+	"log"
+	"net/http"
+	"time"
+)
+
+// Custom response writer to capture status code
+type responseWriter struct {
+	http.ResponseWriter
+	statusCode int
+}
+
+func (rw *responseWriter) WriteHeader(code int) {
+	rw.statusCode = code
+	rw.ResponseWriter.WriteHeader(code)
+}
+
+// Logging Middleware
+func LoggingMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		start := time.Now()
+
+		rw := &responseWriter{
+			ResponseWriter: w,
+			statusCode:     http.StatusOK,
+		}
+
+		next.ServeHTTP(rw, r)
+
+		duration := time.Since(start)
+
+		log.Printf(
+			"%s %s %d %v",
+			r.Method,
+			r.URL.Path,
+			rw.statusCode,
+			duration,
+		)
+	})
+}


### PR DESCRIPTION
Implements BE3-14 by adding request logging middleware.

- logs HTTP method, route, status code, and response time
- applied middleware to all routes (public and protected)
- helps with debugging and monitoring requests