### PR TITLE
FE3-17: Add unit test for expired and revoked download states

### DIFF
--- a/frontend/src/pages/DownloadPage.test.js
+++ b/frontend/src/pages/DownloadPage.test.js
@@ -33,8 +33,8 @@ describe('DownloadPage', () => {
 
     renderDownloadPage();
 
-    const headings = await screen.findAllByText(/resume\.pdf/i);
-    expect(headings.length).toBeGreaterThan(0);
+    const fileNames = await screen.findAllByText(/resume\.pdf/i);
+    expect(fileNames.length).toBeGreaterThan(0);
 
     expect(screen.getByText(/size/i)).toBeInTheDocument();
     expect(screen.getByText(/2\.00 kb/i)).toBeInTheDocument();
@@ -43,7 +43,41 @@ describe('DownloadPage', () => {
     expect(downloadButton).toBeInTheDocument();
   });
 
-  test('displays generic invalid-link state when metadata fetch fails', async () => {
+  test('renders expired link state with correct messaging', async () => {
+    api.fetchFileMetadata.mockRejectedValueOnce(new Error('This share link has expired'));
+
+    renderDownloadPage();
+
+    const expiredHeading = await screen.findByText(/this share link has expired/i);
+    expect(expiredHeading).toBeInTheDocument();
+
+    const expiredElements = screen.getAllByText(/expired/i);
+    expect(expiredElements.length).toBeGreaterThan(0);
+
+    const expiredMessage = screen.getByText(
+      /shared with a limited lifetime, and the download window has ended/i
+    );
+    expect(expiredMessage).toBeInTheDocument();
+  });
+
+  test('renders revoked link state with correct messaging', async () => {
+    api.fetchFileMetadata.mockRejectedValueOnce(new Error('This share link was revoked'));
+
+    renderDownloadPage();
+
+    const revokedHeading = await screen.findByText(/this share link has been revoked/i);
+    expect(revokedHeading).toBeInTheDocument();
+
+    const revokedElements = screen.getAllByText(/revoked/i);
+    expect(revokedElements.length).toBeGreaterThan(0);
+
+    const revokedMessage = screen.getByText(
+      /owner has disabled this link, so the file is no longer available through this url/i
+    );
+    expect(revokedMessage).toBeInTheDocument();
+  });
+
+  test('displays generic invalid-link state when metadata fetch fails with unknown error', async () => {
     api.fetchFileMetadata.mockRejectedValueOnce(new Error('File not found'));
 
     renderDownloadPage();
@@ -51,7 +85,9 @@ describe('DownloadPage', () => {
     const errorHeading = await screen.findByText(/file not found/i);
     expect(errorHeading).toBeInTheDocument();
 
-    const errorMessage = screen.getByText(/invalid, unavailable, or may have been removed/i);
+    const errorMessage = screen.getByText(
+      /invalid, unavailable, or may have been removed/i
+    );
     expect(errorMessage).toBeInTheDocument();
 
     const homeLink = screen.getByText(/back to home/i);


### PR DESCRIPTION
## Summary
Added unit tests for revoked and expired public download states.

## Changes
- Added expired-state test for DownloadPage
- Added revoked-state test for DownloadPage
- Verified user-facing messaging for both states
- Preserved generic invalid-link test coverage

Closes #143 