### PR TITLE
FE3-20: Add public share and download summary to Sprint 3 docs

### DIFF
--- a/Sprint3.md
+++ b/Sprint3.md
@@ -120,3 +120,74 @@ Authorization: Bearer <signed-jwt>
 DELETE /me/files/abc123token
 Authorization: Bearer <signed-jwt>
 ```
+## FE3-20: Public Share and Download Flow Summary
+
+### Overview
+The Sprint 3 recipient flow focuses on improving the public file sharing and download experience. The flow supports successful file access, clearer metadata presentation, and stronger handling of expired, revoked, and invalid links.
+
+### Public Routes
+- `/download`
+  - Lookup page where a user can enter a file token and preview metadata before opening the public download page.
+- `/download/:token`
+  - Public recipient page for a shared file.
+  - Displays file details and allows download when the link is active.
+
+### Recipient Flow
+1. A user uploads a file.
+2. The frontend generates a shareable public link using the file token.
+3. A recipient opens `/download/:token`.
+4. The frontend fetches metadata for the shared token.
+5. If the file is available:
+   - filename is shown
+   - size is shown
+   - uploaded time is shown
+   - expiration information is shown when available
+   - download action is displayed
+6. If the link is invalid, expired, or revoked:
+   - a dedicated public error state is shown
+   - the user is guided back to the lookup page or home page
+
+### Expired and Revoked Link Handling
+Sprint 3 added stronger recipient-facing handling for non-active links.
+
+- **Expired link**
+  - shows a dedicated expired state
+  - explains that the share window has ended
+  - disables download access
+
+- **Revoked link**
+  - shows a dedicated revoked state
+  - explains that the owner disabled the share link
+
+- **Invalid or unknown link**
+  - shows a generic fallback error state
+  - preserves a consistent user experience
+
+### UI/UX Enhancements
+Sprint 3 recipient-flow improvements include:
+- redesigned public download page
+- clearer file metadata presentation
+- visible expiration banner
+- reusable file detail panel
+- share-link panel after upload
+- improved empty, loading, and error states
+- polished public error pages
+- responsive layout for public pages
+
+### Tests Added
+
+#### Unit Tests
+- `src/pages/DownloadPage.test.js`
+  - success metadata render
+  - expired state render
+  - revoked state render
+  - generic invalid-link fallback render
+
+#### Cypress Smoke Test
+- `cypress/e2e/download_page.cy.js`
+  - public download route opens
+  - success state renders
+  - expired error path renders
+
+### Sprint 3 Result
+The recipient-facing public sharing experience is now more reliable, more user-friendly, and better tested across both success and failure states.


### PR DESCRIPTION
## Summary
Documented the public share and download flow for Sprint 3.

## Changes
- Added recipient flow summary
- Documented expired and revoked link handling
- Listed unit and Cypress test coverage
- Summarized Sprint 3 public UX improvements

Closes #146 