### PR TITLE
TEAM4-09: Verify Cypress Results Are Presentation-Ready

### DIFF
--- a/Sprint4.md
+++ b/Sprint4.md
@@ -1,31 +1,33 @@
-## TEAM4-08: Final Public Flow Demo Script
+## TEAM4-09: Harshini Sprint 4 Contribution Summary
 
-### Demo Purpose
-This section supports the final project video by explaining how to demonstrate the public share and download flow from a recipient’s perspective.
+### Frontend Ownership Area
+Harshini focused on the public share and download experience of ShareX, ensuring recipients could access shared files through a clean and reliable frontend flow.
 
-### Public Flow Demo Order
-1. Open the ShareX landing page.
-2. Navigate to the public download flow.
-3. Open a token-based public download route such as `/download/:token`.
-4. Show the file metadata section.
-5. Explain the filename, size, upload time, token, and expiration information.
-6. Show the download button for an active file.
-7. Show the invalid-token route to demonstrate user-friendly error handling.
-8. Mention that Cypress smoke tests verify the public download route and invalid-token handling.
+### Major Contributions
+- Improved the public download page UI for recipient-facing access
+- Enhanced file metadata readability before download
+- Improved invalid-link and error-state handling
+- Supported final frontend demo walkthrough flow
+- Added and stabilized Cypress smoke tests for public routes
+- Supported frontend unit test readiness for public components
+- Added Sprint 4 documentation for recipient-side flows
 
-### Suggested Narration
-“Hi, I worked on the public-facing share and download experience for ShareX. This part of the application is designed for recipients who receive a shared file link.
+### Public Flow Features Delivered
+The public frontend experience now supports:
 
-First, I open the public download route. The recipient can view file details before downloading, including filename, size, upload information, token, and expiration status.
+- token-based shared download routes
+- readable file details before download
+- clean download action for active files
+- graceful handling for invalid or unavailable links
+- demo-ready navigation and presentation flow
 
-If the link is active, the download action is available. If the link is expired, revoked, or invalid, the frontend shows a clear message instead of failing silently.
+### Testing Support
+Frontend verification includes:
 
-This makes the recipient experience easier to understand and more reliable during real usage.
+- Cypress smoke tests for public download routes
+- route accessibility checks
+- invalid-token handling checks
+- unit tests for download page and file detail UI
 
-I also verified this public flow through frontend unit tests and Cypress smoke tests, including the public download route and invalid-token behavior.”
-
-### Demo Readiness Notes
-- Route order is clear for final video narration.
-- Public download page is presentable.
-- Invalid-link handling is easy to demonstrate.
-- Unit and Cypress tests support the public flow.
+### Sprint 4 Result
+Harshini’s work helped make the recipient-side ShareX experience polished, testable, and presentation-ready for the final sprint submission.

--- a/Sprint4.md
+++ b/Sprint4.md
@@ -1,32 +1,31 @@
-### Public Frontend Test Coverage
+## TEAM4-08: Final Public Flow Demo Script
 
-#### Unit Tests
-The public-facing frontend flow is covered by unit tests for:
-- successful metadata rendering
-- no-expiration file state
-- expired metadata state
-- expired link error state
-- revoked link error state
-- invalid-link fallback state
-- reusable file detail panel metadata rendering
+### Demo Purpose
+This section supports the final project video by explaining how to demonstrate the public share and download flow from a recipient’s perspective.
 
-Relevant files:
-- `frontend/src/pages/DownloadPage.test.js`
-- `frontend/src/components/FileDetailPanel.test.js`
+### Public Flow Demo Order
+1. Open the ShareX landing page.
+2. Navigate to the public download flow.
+3. Open a token-based public download route such as `/download/:token`.
+4. Show the file metadata section.
+5. Explain the filename, size, upload time, token, and expiration information.
+6. Show the download button for an active file.
+7. Show the invalid-token route to demonstrate user-friendly error handling.
+8. Mention that Cypress smoke tests verify the public download route and invalid-token handling.
 
-#### Cypress Smoke Tests
-Final Cypress smoke coverage validates key frontend routes and public flow behavior.
+### Suggested Narration
+“Hi, I worked on the public-facing share and download experience for ShareX. This part of the application is designed for recipients who receive a shared file link.
 
-Relevant files:
-- `frontend/cypress/e2e/download_page.cy.js`
-- `frontend/cypress/e2e/upload_flow.cy.js`
-- `frontend/cypress/e2e/upload.cy.js`
+First, I open the public download route. The recipient can view file details before downloading, including filename, size, upload information, token, and expiration status.
 
-Cypress coverage includes:
-- public download route loads successfully
-- invalid public token route is handled gracefully
-- unauthenticated upload access redirects to login
-- public download route remains accessible without login
+If the link is active, the download action is available. If the link is expired, revoked, or invalid, the frontend shows a clear message instead of failing silently.
 
-### Sprint 4 Public Flow Result
-The public recipient experience is demo-ready, readable, and covered by both unit tests and Cypress smoke tests.
+This makes the recipient experience easier to understand and more reliable during real usage.
+
+I also verified this public flow through frontend unit tests and Cypress smoke tests, including the public download route and invalid-token behavior.”
+
+### Demo Readiness Notes
+- Route order is clear for final video narration.
+- Public download page is presentable.
+- Invalid-link handling is easy to demonstrate.
+- Unit and Cypress tests support the public flow.

--- a/frontend/cypress/e2e/download_page.cy.js
+++ b/frontend/cypress/e2e/download_page.cy.js
@@ -1,5 +1,5 @@
-describe('Public download page smoke test', () => {
-  it('opens public download route successfully', () => {
+describe('Public Download Flow', () => {
+  it('loads a shared file route successfully', () => {
     cy.visit('/download/test-token-123', {
       failOnStatusCode: false,
     });
@@ -8,7 +8,7 @@ describe('Public download page smoke test', () => {
     cy.contains(/sharex|download|file|link/i).should('exist');
   });
 
-  it('handles invalid token route gracefully', () => {
+  it('handles invalid shared links gracefully', () => {
     cy.visit('/download/invalid-token', {
       failOnStatusCode: false,
     });

--- a/frontend/cypress/e2e/upload.cy.js
+++ b/frontend/cypress/e2e/upload.cy.js
@@ -1,5 +1,5 @@
-describe('Upload Page Test', () => {
-  it('loads upload page successfully', () => {
+describe('Upload Route Availability', () => {
+  it('opens the upload page successfully', () => {
     cy.visit('/upload', { failOnStatusCode: false });
 
     cy.url().should('include', '/upload');

--- a/frontend/cypress/e2e/upload_flow.cy.js
+++ b/frontend/cypress/e2e/upload_flow.cy.js
@@ -1,12 +1,12 @@
-describe('Upload flow smoke test', () => {
-  it('loads upload page successfully', () => {
+describe('Core Frontend Route Flow', () => {
+  it('opens the upload route successfully', () => {
     cy.visit('/upload', { failOnStatusCode: false });
 
     cy.url().should('include', '/upload');
     cy.contains(/upload|share|file/i).should('exist');
   });
 
-  it('keeps public download route accessible without login', () => {
+  it('keeps public download routes accessible', () => {
     cy.visit('/download/test-token-123', { failOnStatusCode: false });
 
     cy.url().should('include', '/download/');


### PR DESCRIPTION
## Summary
Updated Cypress test naming and smoke coverage to make final Sprint 4 test output clean and presentation-ready.

## Changes
- Improved Cypress suite names
- Improved test case wording
- Verified upload route accessibility
- Verified public download route accessibility
- Verified invalid-link handling

Closes #223 