### PR TITLE
BE4-07: add backend tests

### DIFF
--- a/backend/internal/handlers/auth_test.go
+++ b/backend/internal/handlers/auth_test.go
@@ -1,0 +1,43 @@
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHealthEndpoint(t *testing.T) {
+	req, err := http.NewRequest("GET", "/health", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Errorf("expected status 200, got %v", rr.Code)
+	}
+}
+
+func TestInvalidRoute(t *testing.T) {
+	req, err := http.NewRequest("GET", "/invalid", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+
+	handler := http.NotFoundHandler()
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %v", rr.Code)
+	}
+}

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "backend",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
Closing this PR after completing BE4-06.

Final backend API documentation has been added and structured in the README
Includes request/response formats, authentication details, and error cases
Ready for Sprint 4 submission